### PR TITLE
Bug fix in post gen hook script

### DIFF
--- a/hooks/post_gen_project.bat
+++ b/hooks/post_gen_project.bat
@@ -1,4 +1,4 @@
-if not exists .git (
+if not exist .git (
     echo "Creating git repo."
     git init
 )

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -27,7 +27,6 @@ dev = [
     "setuptools ~= 69.0.3",
     "wheel ~= 0.40.0",
     "setuptools-git-versioning < 2",
-    "pip-tools ~= 7.3.0",
     "black~=22.1.0",
     "flake8==6.0.0",
     "Flake8-pyproject==1.2.3",


### PR DESCRIPTION
Small fixes to get it working under windows:
1. Fixed batch script
2. removed pip-tools dependencies, since this results in a clash when pip-tools are also used to install it.